### PR TITLE
Update DeviceTypeName() to return the correct name for ORT

### DIFF
--- a/c10/core/DeviceType.cpp
+++ b/c10/core/DeviceType.cpp
@@ -32,7 +32,7 @@ std::string DeviceTypeName(DeviceType d, bool lower_case) {
     case DeviceType::Metal:
       return lower_case ? "metal" : "METAL";
     case DeviceType::ORT:
-      return lower_case ? "ort" : "METAL";
+      return lower_case ? "ort" : "ORT";
     default:
       AT_ERROR(
           "Unknown device: ",


### PR DESCRIPTION
I noticed this when reading through the code: not sure if this string is just used for display or if it is ever used as a key.