### PR TITLE
initial draft of op generation from a config file

### DIFF
--- a/test/ort_eager/test_ort_eager.py
+++ b/test/ort_eager/test_ort_eager.py
@@ -14,5 +14,21 @@ class TestCustomOps(unittest.TestCase):
         z_pt = x.cpu() + y.cpu()
         assert torch.allclose(z.cpu(), z_pt)
     
+    def test_sub(self):
+        device = torch.device("ort")
+        x = torch.empty(5, 3, device = device)
+        y = torch.empty(5, 3, device = device)
+        z = x - y
+        z_pt = x.cpu() - y.cpu()
+        assert torch.allclose(z.cpu(), z_pt)
+    
+    def test_relu(self):
+        device = torch.device("ort")
+        x = torch.empty(5, 3, device = device)
+        z = torch.relu(x)
+        z_pt = torch.relu(x.cpu())
+        assert torch.allclose(z.cpu(), z_pt)
+
+    
 if __name__ == '__main__':
     unittest.main()

--- a/torch_onnxruntime/ORTAtenHelper.cpp
+++ b/torch_onnxruntime/ORTAtenHelper.cpp
@@ -1,0 +1,45 @@
+#include "ORTAtenHelper.h"
+#include "ORTTensorImpl.h"
+#include "ORTUtil.h"
+
+namespace at {
+namespace native {
+namespace ort {
+namespace aten {
+
+using namespace at::native::ort::detail;
+using ORTTensorImpl = ORTOpaqueTensorImpl<OrtValue>;
+
+Tensor new_with_orttensor_ort(
+  OrtValue&& ot,
+  const TensorOptions& options) {
+  const onnxruntime::Tensor& tensor = ot.Get<onnxruntime::Tensor>();
+  auto &sizes = tensor.Shape().GetDims();
+  //TODO: optimize it later
+  auto strides = GetStride(sizes, tensor.DataType()->Size());
+  return at::detail::make_tensor<ORTTensorImpl>(
+    DispatchKeySet(DispatchKey::ORT),
+    options.dtype(),
+    at::Device(at::kORT),
+    std::move(ot),
+    std::vector<int64_t>(sizes.begin(), sizes.end()),
+    std::vector<int64_t>(strides.begin(), strides.end()));
+}
+
+const OrtValue& orttensor_from_ort(const Tensor& tensor) {
+  // FIXME: assert tensor is from ORT
+  auto impl = static_cast<ORTTensorImpl*>(tensor.unsafeGetTensorImpl());
+  return impl->unsafe_opaque_handle();
+}
+
+OrtValue& orttensor_from_ort(Tensor& tensor) {
+  // FIXME: assert tensor is from ORT
+  auto impl = static_cast<ORTTensorImpl*>(tensor.unsafeGetTensorImpl());
+  return impl->unsafe_opaque_handle();
+}
+
+
+}
+}
+}
+}

--- a/torch_onnxruntime/ORTAtenHelper.h
+++ b/torch_onnxruntime/ORTAtenHelper.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <torch/extension.h>
+#include "core/framework/ml_value.h"
+#include "core/framework/tensor.h"
+
+
+namespace at {
+namespace native {
+namespace ort {
+namespace aten {
+
+Tensor new_with_orttensor_ort(OrtValue&& ot, const TensorOptions& options);
+
+const OrtValue& orttensor_from_ort(const Tensor& tensor);
+
+OrtValue& orttensor_from_ort(Tensor& tensor);
+
+}
+}
+}
+}

--- a/torch_onnxruntime/opgen/onnx_ops.config
+++ b/torch_onnxruntime/opgen/onnx_ops.config
@@ -1,0 +1,8 @@
+{"aten_op": "aten::empty.memory_format", "handle": "Customize", "unbox_registration": true}
+{"aten_op": "aten::reshape", "handle": "Customize", "unbox_registration": false}
+{"aten_op": "aten::view", "handle": "Customize", "unbox_registration": false}
+{"aten_op": "aten::copy_", "handle": "Customize", "unbox_registration": false}
+{"aten_op": "aten::add.Tensor", "handle": "Generated", "unbox_registration": false, "onnx_op": "Add", "inputs": [0, 1]}
+{"aten_op": "aten::sub.Tensor", "handle": "Generated", "unbox_registration": false, "onnx_op": "Sub", "inputs": [0, 1]}
+{"aten_op": "aten::mul.Tensor", "handle": "Generated", "unbox_registration": false, "onnx_op": "Mul", "inputs": [0, 1]}
+{"aten_op": "aten::relu", "handle": "Generated", "unbox_registration": false, "onnx_op": "Relu", "inputs": [0]}

--- a/torch_onnxruntime/opgen/opgen.py
+++ b/torch_onnxruntime/opgen/opgen.py
@@ -21,8 +21,93 @@ regdecs_path = os.path.realpath(os.path.join(
   'ATen',
   'RegistrationDeclarations.h'))
 
+def generate_includes(writer):
+  writer.write('#include <torch/extension.h> \n')
+  writer.write('#include "ORTUtil.h" \n')
+  writer.write('#include "ORTTensorImpl.h" \n')
+  writer.write('#include "ORTOps.h" \n')
+  writer.write('#include "ORTAtenHelper.h" \n')
+
+def begin_namespace(writer):
+  writer.write('namespace at { \n')
+  writer.write('namespace native { \n')
+  writer.write('namespace ort { \n')
+  writer.write('namespace aten { \n')
+
+def using_stmts(writer):
+  writer.write('using namespace at::native::ort::detail; \n')
+
+def end_namespace(writer):
+  writer.write('}\n')
+  writer.write('}\n')
+  writer.write('}\n')
+  writer.write('}\n')
+
+def load_config(path):
+  result = {}
+  with open(path) as f:
+    s = f.readline()
+    while s:
+      op = json.loads(s)
+      result[op["aten_op"]] = op
+      s = f.readline()
+  return result
+
+def gen_onnx_handle(writer, op_config, cpp_func):
+  # logging
+  writer.write('ORT_LOG << "%s"; \n' % cpp_func.ort_name)
+  # get ort kernel invoker
+  assert(len(cpp_func.parameters) > 0)
+  writer.write("auto& invoker = GetORTInvoker(")
+  writer.write(cpp_func.parameters[0].member.identifier.value)
+  writer.write('.device()); \n')
+  # prepare inputs
+  i = 0
+  inputs = []
+  for index in op_config["inputs"]:
+    writer.write('auto& input_%d = orttensor_from_ort(%s); \n' % 
+                 (i, cpp_func.parameters[index].member.identifier.value))
+    inputs.append('input_%d' % i)
+    i += 1
+  
+
+  # prepare ort outputs:
+  ort_output_name = 'results'
+  # todo: how to handle multiple result
+  writer.write('std::vector<OrtValue> %s(1); \n' % ort_output_name)
+  # invoke ort kernel
+  # todo: handle attributes
+  writer.write('auto status = invoker.Invoke("%s", {%s}, %s, nullptr);\n' % 
+                (op_config["onnx_op"], ','.join(inputs), ort_output_name))
+  # status check
+  writer.write('if (!status.IsOK()) \n')
+  writer.write('  throw std::runtime_error("ORT return failure status: " + status.ErrorMessage()); \n')
+  # logging
+  writer.write('ORT_LOG << "Invoke ORT %s kernel successfully";\n' % op_config['onnx_op'])
+  # construct result
+  ort_value_name = 'ort_result'
+  writer.write('OrtValue %s = %s[0]; \n' % (ort_value_name, ort_output_name))
+  # todo: handle mutliple result
+  # todo: return type check
+  writer.write('return new_with_orttensor_ort(std::move(%s), %s.options()); \n' %
+               (ort_value_name, cpp_func.parameters[0].member.identifier.value))
+
+def write_func_signature(writer, cpp_func):
+  cpp_func.return_type.write(writer)
+  writer.write(" ")
+  writer.write(cpp_func.ort_name)
+  writer.write("(")
+  for param_list_member in cpp_func.parameters:
+    param_list_member.write(writer)
+  writer.write(")")
+
 with opgen.parser.cpp_create_from_file(regdecs_path) as parser:
   writer = sys.stdout
+  op_configs = load_config('onnx_ops.config')
+
+  generate_includes(writer)
+  begin_namespace(writer)
+  using_stmts(writer)
   generated_funcs = []
 
   # Parse the C++ declarations
@@ -44,35 +129,48 @@ with opgen.parser.cpp_create_from_file(regdecs_path) as parser:
           torch_func.torch_default = metadata["default"] == "True"
     if not torch_func:
       continue
+    
+    if torch_func.identifier.value not in op_configs:
+      continue
 
-    cpp_func.ort_name = "ort_" + torch_func.identifier.value.replace("::", "_")
+    op_config = op_configs[torch_func.identifier.value]
+
+    cpp_func.ort_name = "ort_" + torch_func.identifier.value.replace("::", "_").replace(".", "_")
+    if 'ort_aten_rename' in cpp_func.ort_name:
+      continue
 
     writer.write(f"// {torch_func.torch_schema}\n")
 
-    # Write the C++ signature for our ORT implementation
-    writer.write("static ")
-    cpp_func.return_type.write(writer)
-    writer.write(" ")
-    writer.write(cpp_func.ort_name)
-    writer.write("(")
-    for param_list_member in cpp_func.parameters:
-      param_list_member.write(writer)
-    writer.write(")\n{\n")
+    if op_config["handle"] == "Customize":
+      # write the extern func declaration:
+      writer.write("extern ")
+      write_func_signature(writer, cpp_func)
+      writer.write(";\n")
+    else:
+      # Write the C++ signature for our ORT implementation
+      writer.write("static ")
+      write_func_signature(writer, cpp_func)
+      writer.write("\n{\n")
 
-    writer.write("    //  Return: ")
-    torch_func.return_type.write(writer)
-    writer.write("\n")
 
-    # Do something for each parameter; cpp_func and torch_func should have
-    # 1:1 parameters, but the metadata on the torch_func is richer than
-    # the cpp_func version.
-    for i, param_list_member in enumerate(torch_func.parameters):
-      writer.write(f"    // Param {i}: ")
-      param_list_member.member.write(writer)
+      writer.write("    //  Return: ")
+      torch_func.return_type.write(writer)
       writer.write("\n")
 
-    # Finalize the ORT implementation
-    writer.write("}\n\n")
+      # Do something for each parameter; cpp_func and torch_func should have
+      # 1:1 parameters, but the metadata on the torch_func is richer than
+      # the cpp_func version.
+      for i, param_list_member in enumerate(torch_func.parameters):
+        writer.write(f"    // Param {i}: ")
+        param_list_member.member.write(writer)
+        writer.write("\n")
+
+      if op_config["handle"] == "Generated":
+        gen_onnx_handle(writer, op_config, cpp_func)
+      else:
+        writer.write('throw std::runtime_error("Not Implemented");')
+      # Finalize the ORT implementation
+      writer.write("}\n\n")
 
     generated_funcs.append((cpp_func, torch_func))
 
@@ -80,5 +178,14 @@ with opgen.parser.cpp_create_from_file(regdecs_path) as parser:
   writer.write("TORCH_LIBRARY_IMPL(aten, ORT, m) {\n")
   writer.write("    ORT_LOG << \"ATen init\";\n")
   for cpp_func, torch_func in generated_funcs:
-    writer.write(f"    m.impl(\"{torch_func.identifier.value}\", TORCH_FN({cpp_func.ort_name}));\n")
+    if torch_func.identifier.value not in op_configs:
+      continue
+    op_config = op_configs[torch_func.identifier.value]
+
+    if op_config["unbox_registration"]:
+      writer.write(f"    m.impl_UNBOXED(\"{torch_func.identifier.value}\", ({cpp_func.ort_name}));\n")
+    else:
+      writer.write(f"    m.impl(\"{torch_func.identifier.value}\", TORCH_FN({cpp_func.ort_name}));\n")
   writer.write("}\n")
+
+  end_namespace(writer)

--- a/torch_onnxruntime/opgen/opgen.py
+++ b/torch_onnxruntime/opgen/opgen.py
@@ -21,6 +21,10 @@ regdecs_path = os.path.realpath(os.path.join(
   'ATen',
   'RegistrationDeclarations.h'))
 
+onnx_ops_config_path = os.path.realpath(os.path.join(
+  os.path.dirname(__file__),
+  'onnx_ops.config'))
+
 def generate_includes(writer):
   writer.write('#include <torch/extension.h> \n')
   writer.write('#include "ORTUtil.h" \n')
@@ -101,9 +105,13 @@ def write_func_signature(writer, cpp_func):
     param_list_member.write(writer)
   writer.write(")")
 
-with opgen.parser.cpp_create_from_file(regdecs_path) as parser:
+if len(sys.argv) == 2:
+  writer = open(sys.argv[1], 'wt')
+else:
   writer = sys.stdout
-  op_configs = load_config('onnx_ops.config')
+
+with opgen.parser.cpp_create_from_file(regdecs_path) as parser:
+  op_configs = load_config(onnx_ops_config_path)
 
   generate_includes(writer)
   begin_namespace(writer)
@@ -189,3 +197,5 @@ with opgen.parser.cpp_create_from_file(regdecs_path) as parser:
   writer.write("}\n")
 
   end_namespace(writer)
+
+writer.close()

--- a/torch_onnxruntime/opgen/opgen/ast.py
+++ b/torch_onnxruntime/opgen/opgen/ast.py
@@ -46,6 +46,12 @@ class SyntaxList(Node):
 
   def __iter__(self):
     return self.members.__iter__()
+  
+  def __getitem__(self, key):
+    return self.members.__getitem__(key)
+  
+  def __len__(self):
+    return len(self.members)
 
   def append(self, member: Node, trailing_separator: Token):
     self.members.append(SyntaxListMember(member, trailing_separator))

--- a/torch_onnxruntime/setup.py
+++ b/torch_onnxruntime/setup.py
@@ -13,6 +13,14 @@ def build_ort(ort_path, build_dir, debug=False):
             '--skip_submodule_sync', '--build', '--update', '--parallel']    
     subprocess.run(args)
 
+def gen_ort_aten_ops():
+    gen_cpp_name = "gen.cpp"
+    if os.path.exists(gen_cpp_name):
+        os.remove(gen_cpp_name)
+    args = ['python', os.path.join(os.path.dirname(__file__), 'opgen', 'opgen.py'),
+             gen_cpp_name]
+    subprocess.run(args)
+
 build_ort('onnxruntime', 'ort_build')
 
 current_path = os.path.abspath(os.getcwd())
@@ -47,6 +55,8 @@ external_libs = [ort_build_root + '/external/nsync/libnsync_cpp.a',
               ort_build_root + '/external/protobuf/cmake/libprotobuf.a',
               ort_build_root + '/external/re2/libre2.a',]
 ort_static_libs.extend(external_libs)
+
+gen_ort_aten_ops()
 
 setup(
     name='torch_ort',

--- a/torch_onnxruntime/test.py
+++ b/torch_onnxruntime/test.py
@@ -13,3 +13,13 @@ z2 = x.cpu() + y.cpu()
 print(z.size())
 print(z.cpu())
 print(z2)
+
+s = x - y
+print(s.cpu())
+
+m = x * y
+print(m.cpu())
+
+r = torch.relu(x)
+print(r.cpu())
+


### PR DESCRIPTION
This PR include:

1. update the opgen script to support 1) for simple ops we can generate the ort invoke code from a configuration file. 2) fo complicated ops that need manually handle, it generate the extern function declaration, so we can linked with those manually written functions.
2.  Update the registration part with two types, normal implementation and UNBOXED implementation
3.  Implement several simple ops (Sub and Relu) based on this configuration. Add them to CI test