### PR TITLE
Revert "map pytorch dtype to ort type"

### DIFF
--- a/torch_onnxruntime/ort_aten.cpp
+++ b/torch_onnxruntime/ort_aten.cpp
@@ -29,27 +29,6 @@ OrtValue& orttensor_from_ort(at::Tensor& tensor) {
   return impl->tensor();
 }
 
-onnxruntime::MLDataType get_ort_scalar_type_from_aten(at::ScalarType dtype){
-  switch (dtype){
-    case at::kFloat:
-      return onnxruntime::DataTypeImpl::GetType<float>();
-    case at::kDouble:
-      return onnxruntime::DataTypeImpl::GetType<double>();
-    case at::kHalf:
-      return onnxruntime::DataTypeImpl::GetType<onnxruntime::MLFloat16>();
-    case at::kBFloat16:
-      return onnxruntime::DataTypeImpl::GetType<onnxruntime::BFloat16>();
-    case at::kInt:
-      return onnxruntime::DataTypeImpl::GetType<int>();
-    case at::kShort:
-      return onnxruntime::DataTypeImpl::GetType<int16_t>();
-    case at::kLong:
-      return onnxruntime::DataTypeImpl::GetType<int64_t>();
-    default:
-      ORT_THROW("Unsupport aten scalar type: ", dtype);
-  }
-}
-
 #pragma endregion
 
 at::Tensor ort_aten_empty_memory_format(
@@ -67,10 +46,10 @@ at::Tensor ort_aten_empty_memory_format(
   // TODO: figure out how to get the correct element type.
   OrtValue ot;
   auto& invoker = GetORTInvoker(options.device());
-  CreateMLValue(
+  CreateMLValue<float>(
     invoker.GetCurrentExecutionProvider().GetAllocator(0, OrtMemTypeDefault),
-    get_ort_scalar_type_from_aten(at::kFloat),
     size.vec(),
+    {},
     &ot);
 
   return new_with_orttensor_ort(
@@ -95,10 +74,10 @@ at::Tensor ort_aten_empty_strided(
   assert(!layout_opt.has_value());
   at::ScalarType dtype = c10::dtype_or_default(dtype_opt);
   auto& invoker = GetORTInvoker(*device_opt);
-  CreateMLValue(
+  CreateMLValue<float>(
     invoker.GetCurrentExecutionProvider().GetAllocator(0, OrtMemTypeDefault),
-    get_ort_scalar_type_from_aten(dtype),
     size.vec(),
+    {},
     &ot);
   return new_with_orttensor_ort(
     std::move(ot),
@@ -139,7 +118,7 @@ namespace{
     tensor.data_ptr();
     //todo: figure out the correct type
     OrtValue ot;
-    CreateMLValue(tensor.data_ptr(), get_ort_scalar_type_from_aten(tensor.scalar_type()), tensor.sizes().vec(), &ot);
+    CreateMLValue<float>(tensor.data_ptr(), tensor.sizes().vec(), &ot);
     return ot;
   }
 
@@ -148,7 +127,7 @@ namespace{
     tensor.data_ptr();
     //todo: figure out the correct type
     OrtValue ot;
-    CreateMLValue(tensor.data_ptr(), get_ort_scalar_type_from_aten(tensor.scalar_type()), tensor.sizes().vec(), &ot);
+    CreateMLValue<float>(tensor.data_ptr(), tensor.sizes().vec(), &ot);
     return ot;
   }
 }

--- a/torch_onnxruntime/ort_aten.h
+++ b/torch_onnxruntime/ort_aten.h
@@ -18,7 +18,5 @@ const OrtValue& orttensor_from_ort(const at::Tensor& tensor);
 
 OrtValue& orttensor_from_ort(at::Tensor& tensor);
 
-onnxruntime::MLDataType get_ort_scalar_type_from_aten(at::ScalarType dtype);
-
 } // namespace eager
 } // namespace torch_ort

--- a/torch_onnxruntime/ort_ops.cpp
+++ b/torch_onnxruntime/ort_ops.cpp
@@ -17,11 +17,8 @@ OrtValue reshape_copy(
   auto new_shape = at::infer_size(shape, input_tensor.Shape().Size());
   OrtValue shape_tensor;
   //todo: avoid the copy on this small shape vector;
-  auto element_type = onnxruntime::DataTypeImpl::GetType<int64_t>();
-  CreateMLValue(invoker.GetCurrentExecutionProvider().GetAllocator(0, OrtMemTypeDefault),
-                element_type, {(int64_t)new_shape.size(),}, &shape_tensor);
-  auto* ort_shape_tensor = shape_tensor.GetMutable<onnxruntime::Tensor>();
-  CopyVectorToTensor<int64_t>(new_shape, *ort_shape_tensor);
+  CreateMLValue<int64_t>(invoker.GetCurrentExecutionProvider().GetAllocator(0, OrtMemTypeDefault),
+                       {(int64_t)new_shape.size(),}, new_shape, &shape_tensor);
   std::vector<OrtValue> result(1);
   ORT_LOG << "Invoke ORT reshape kernel";
   auto status = invoker.Invoke("Reshape", {input, shape_tensor}, result, nullptr);

--- a/torch_onnxruntime/test_models/scratchpad.py
+++ b/torch_onnxruntime/test_models/scratchpad.py
@@ -22,7 +22,7 @@ fenced_ten = torch.tensor(
   [[-1, -1, -1],
    [-1, 10, -1],
    [-1, -1, -1]],
-  device = device, dtype=torch.float)
+  device = device)
 
 print(fenced_ten.numel())
 print(fenced_ten.size())


### PR DESCRIPTION
Reverts microsoft/onnxruntime-pytorch#13

Seems to be missing the new `CreateMLValue` implementations in `ort_util.cpp`.

```
Symbol not found: __ZN9torch_ort5eager13CreateMLValueENSt3__110shared_ptrIN11onnxruntime10IAllocatorEEEPKNS3_12DataTypeImplERKNS1_6vectorIxNS1_9allocatorIxEEEEP8OrtValue
```