### PR TITLE
Quick and dirty added support for building debug mode.

### DIFF
--- a/torch_onnxruntime/setup.py
+++ b/torch_onnxruntime/setup.py
@@ -11,7 +11,11 @@ import subprocess
 import sys
 
 python_exe = sys.executable
-build_config = 'Release'
+
+if os.environ.get('TORCH_ORT_BUILD_CONFIG'):
+    build_config = os.environ['TORCH_ORT_BUILD_CONFIG']
+else:
+    build_config = 'Release'
 
 def is_debug_build():
     return build_config != 'Release'


### PR DESCRIPTION
Added support to read build_config from an environment variable, so I don't have to edit setup.py. I looked at adding a parameter, but it interferes with the setuptools parameter support. We can design something more elaborate in the future.