### PR TITLE
map dropout op and add tests

### DIFF
--- a/torch_onnxruntime/opgen/opgen.py
+++ b/torch_onnxruntime/opgen/opgen.py
@@ -53,6 +53,10 @@ class Mod(ONNXOp):
   def __init__(self, A, B, Fmod=None):
     super().__init__('Mod', 1, A, B,
       Fmod=ONNXAttr(Fmod, ONNXType.INT))
+      
+class Dropout(ONNXOp):
+  def __init__(self, data, ratio, training_mode, seed=None):
+    super().__init__('Dropout', 1, data, ratio, training_mode, seed=seed)
 
 single_arg_op_names = ["data", "_shape_as_tensor", "abs", "absolute", "angle", "sgn",
 "_conj", "acos", "arccos", "acosh", "arccosh", "asinh", "arcsinh",
@@ -109,7 +113,7 @@ ops = {
   'aten::t': Transpose('self'),
   'aten::relu': Relu('self'),
   'aten::mm': MatMul('self', 'mat2'),
-  
+  'aten::dropout': Dropout('input', 'p', 'train'),
   'aten::sum.dim_IntList': ReduceSum('self', 'dim', KeepDims='keepdim'),
   'aten::threshold_backward': ReluGrad('grad_output', 'self'),
 

--- a/torch_onnxruntime/test_models/scratchpad.py
+++ b/torch_onnxruntime/test_models/scratchpad.py
@@ -43,5 +43,7 @@ print (d.cpu ())
 a = torch.tensor([[10, 10]], dtype=torch.float).to(device)
 b = torch.tensor([[3.3, 3.3]]).to(device)
 c = torch.fmod(a, b)
-
 print(c.cpu())
+
+drop = torch.nn.functional.dropout(torch.tensor([[1, 1, 1, 1, 1]], dtype=torch.float), 0.5, True)
+print(drop.cpu())

--- a/torch_onnxruntime/test_models/scratchpad.py
+++ b/torch_onnxruntime/test_models/scratchpad.py
@@ -45,5 +45,6 @@ b = torch.tensor([[3.3, 3.3]]).to(device)
 c = torch.fmod(a, b)
 print(c.cpu())
 
-drop = torch.nn.functional.dropout(torch.tensor([[1, 1, 1, 1, 1]], dtype=torch.float), 0.5, True)
+a = torch.tensor([[1, 1, 1, 1, 1]], dtype=torch.float).to(device)
+drop = torch.dropout(a, 0.5, True)
 print(drop.cpu())


### PR DESCRIPTION
(new PR to keep on separate branch for my own sanity)

This attempts to add the dropout operator. Unfortunately, we find a dependency on another op, which is not easily mappable in ORT :/

Traceback (most recent call last): File "scratchpad.py", line 49, in <module> drop = torch.dropout(a, 0.5, True) RuntimeError: Could not run 'aten::bernoulli_.float' with arguments from the 'ORT' backend. 'aten::bernoulli_.float' is only available for these backends: [CPU, BackendSelect, Named, AutogradOther, AutogradCPU, AutogradCUDA, AutogradXLA, AutogradORT, AutogradPrivateUse1, AutogradPrivateUse2, AutogradPrivateUse3, Tracer, Autocast, Batched, VmapMode].