### PR TITLE
add harshrink and softshrink

### DIFF
--- a/torch_onnxruntime/opgen/opgen.py
+++ b/torch_onnxruntime/opgen/opgen.py
@@ -40,7 +40,7 @@ ops = {
   'aten::fmod.Scalar': Mod('self', 'other', fmod=1),
   'aten::fmod.Tensor': Mod('self', 'other', fmod=1),
 
-  'aten::softshrink': Shrink('self', bias=1.5, lambd='lambd'),
+  'aten::softshrink': Shrink('self', bias='lambd', lambd='lambd'), #yes, bias is set to 'lambd'
   'aten::hardshrink': Shrink('self', bias=0, lambd='lambd'),
 }
 

--- a/torch_onnxruntime/opgen/opgen.py
+++ b/torch_onnxruntime/opgen/opgen.py
@@ -33,13 +33,15 @@ ops = {
   'aten::addmm': Gemm('mat1', 'mat2', 'self', alpha='alpha', beta='beta'),
   'aten::t': Transpose('self'),
   'aten::mm': MatMul('self', 'mat2'),
-  'aten::hardshrink': Shrink('self', bias=0, 'lambd'),
-  'aten::softshrink': Shrink('self', 'bias', 'lambd'),
-  'aten::sum.dim_IntList': ReduceSum('self', 'dim', KeepDims='keepdim'),
+
+  'aten::sum.dim_IntList': ReduceSum('self', 'dim', keepdims='keepdim'),
   'aten::threshold_backward': ReluGrad('grad_output', 'self'),
 
   'aten::fmod.Scalar': Mod('self', 'other', fmod=1),
   'aten::fmod.Tensor': Mod('self', 'other', fmod=1),
+
+  'aten::softshrink': Shrink('self', bias=1.5, lambd='lambd'),
+  'aten::hardshrink': Shrink('self', bias=0, lambd='lambd'),
 }
 
 for binary_op, onnx_op in {

--- a/torch_onnxruntime/opgen/opgen.py
+++ b/torch_onnxruntime/opgen/opgen.py
@@ -33,8 +33,9 @@ ops = {
   'aten::addmm': Gemm('mat1', 'mat2', 'self', alpha='alpha', beta='beta'),
   'aten::t': Transpose('self'),
   'aten::mm': MatMul('self', 'mat2'),
-  
-  'aten::sum.dim_IntList': ReduceSum('self', 'dim', keepdims='keepdim'),
+  'aten::hardshrink': Shrink('self', bias=0, 'lambd'),
+  'aten::softshrink': Shrink('self', 'bias', 'lambd'),
+  'aten::sum.dim_IntList': ReduceSum('self', 'dim', KeepDims='keepdim'),
   'aten::threshold_backward': ReluGrad('grad_output', 'self'),
 
   'aten::fmod.Scalar': Mod('self', 'other', fmod=1),

--- a/torch_onnxruntime/test_models/scratchpad.py
+++ b/torch_onnxruntime/test_models/scratchpad.py
@@ -48,6 +48,6 @@ print(c.cpu())
 
 a = torch.tensor([[5, 3, -5]], dtype=torch.float).to(device)
 b = torch.hardshrink(a, 3) #should be [5, 0, -5]
-c = torch.softshrink(a, 3) #should be [2, 0, -2]
+c = torch.nn.functional.softshrink(a, 3) #should be [2, 0, -2]
 print(b.cpu())
 print(c.cpu())

--- a/torch_onnxruntime/test_models/scratchpad.py
+++ b/torch_onnxruntime/test_models/scratchpad.py
@@ -45,3 +45,9 @@ b = torch.tensor([[3.3, 3.3]]).to(device)
 c = torch.fmod(a, b)
 
 print(c.cpu())
+
+a = torch.tensor([[5, 3, -5]], dtype=torch.float).to(device)
+b = torch.hardshrink(a, 3) #should be [5, 0, -5]
+c = torch.softshrink(a, 3) #should be [2, 0, -2]
+print(b.cpu())
+print(c.cpu())


### PR DESCRIPTION
Maps [torch.nn.functional.hardshrink](https://pytorch.org/docs/stable/generated/torch.nn.Hardshrink.html#torch.nn.Hardshrink) and [torch.nn.functional.softshrink](https://pytorch.org/docs/stable/generated/torch.nn.Softshrink.html) to ONNX [Shrink](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Shrink).

Note: I *think* the bias on softshrink needs to equal the lambda to get the results described in torch documentation, but someone should double-check this work.