### PR TITLE
Moved initialization of environment to torch_ort module

### DIFF
--- a/torch_onnxruntime/ort_backends.cpp
+++ b/torch_onnxruntime/ort_backends.cpp
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include <core/providers/cpu/cpu_execution_provider.h>
-
+#include <core/common/logging/sinks/clog_sink.h>
 #include "ort_backends.h"
 #include "ort_log.h"
 
@@ -12,7 +12,13 @@ namespace eager {
 using namespace onnxruntime;
 
 ORTBackendsManager& GetORTBackendsManager() {
-  static ORTBackendsManager instance;
+  const std::string logger_id{"torch_ort"};
+  static auto logging_manager = onnxruntime::make_unique<logging::LoggingManager>(
+      std::unique_ptr<logging::ISink>{new logging::CLogSink{}},
+      logging::Severity::kVERBOSE, false,
+      logging::LoggingManager::InstanceType::Default,
+      &logger_id); 
+  static ORTBackendsManager instance {logging_manager->DefaultLogger()};
   return instance;
 }
 
@@ -36,7 +42,8 @@ onnxruntime::ORTInvoker& ORTBackendsManager::GetInvoker(const at::Device device)
 
   auto invoker = 
     onnxruntime::make_unique<onnxruntime::ORTInvoker>(
-      std::move(ep));
+      std::move(ep),
+      logger_);
 
   backends_[device.index()] = std::move(invoker);
   return *backends_[device.index()];

--- a/torch_onnxruntime/ort_backends.h
+++ b/torch_onnxruntime/ort_backends.h
@@ -19,7 +19,7 @@ public:
     kDirectML = 3
   };
 
-  ORTBackendsManager() {
+  ORTBackendsManager(const onnxruntime::logging::Logger& logger) : logger_(logger) {
     backend_kinds_[ORTDeviceKind::kCPU] = "cpu";
     backend_kinds_[ORTDeviceKind::kCUDA] = "cuda";
     backend_kinds_[ORTDeviceKind::kDirectML] = "direct_ml";
@@ -34,6 +34,7 @@ public:
 private:
   std::map<ORTDeviceKind, std::string> backend_kinds_;
   std::map<at::DeviceIndex, std::unique_ptr<onnxruntime::ORTInvoker>> backends_;
+  const onnxruntime::logging::Logger& logger_;
 };
 
 ORTBackendsManager& GetORTBackendsManager();

--- a/torch_onnxruntime/test/test.py
+++ b/torch_onnxruntime/test/test.py
@@ -1,0 +1,6 @@
+import torch
+import torch_ort
+
+cpu_ones = torch.Tensor([[1, 1, 1], [1, 1, 1], [1, 1, 1]])
+ort_ones = cpu_ones.to(torch_ort.device.cpu())
+torch.sin_(ort_ones)

--- a/torch_onnxruntime/test/test.py
+++ b/torch_onnxruntime/test/test.py
@@ -1,6 +1,0 @@
-import torch
-import torch_ort
-
-cpu_ones = torch.Tensor([[1, 1, 1], [1, 1, 1], [1, 1, 1]])
-ort_ones = cpu_ones.to(torch_ort.device.cpu())
-torch.sin_(ort_ones)


### PR DESCRIPTION
This is the torch_ort reaction for this ORT PR: https://github.com/microsoft/onnxruntime/pull/7342/files. 

Currently ort_kernel_invoker uses a singleton environment which is used for logging and initialized the first time ort_kernel_invoker is constructed. This revealed an issue with Apollo ExecutionProvider integration. During creation of EP, it uses the logger which fails due to it being null. I am switching this so that ort_kernel_invoker simply takes a logger for construction. The environment will be maintained by the caller in this case torch_ort module.

Torch_ORT should own the environment as this is consistent with how onnxruntime_pybind_state.

