### PR TITLE
use ConstantOfShape op to implement zeros_like

### DIFF
--- a/torch_onnxruntime/opgen/opgen.py
+++ b/torch_onnxruntime/opgen/opgen.py
@@ -24,7 +24,6 @@ ops = {
   # Hand-Implemented Ops
   'aten::empty.memory_format': SignatureOnly(),
   'aten::empty_strided': SignatureOnly(),
-  'aten::zeros_like': SignatureOnly(),
   'aten::zero_': SignatureOnly(),
   'aten::copy_': SignatureOnly(),
   'aten::reshape': SignatureOnly(),
@@ -33,6 +32,7 @@ ops = {
   'aten::addmm': Gemm('mat1', 'mat2', 'self', alpha='alpha', beta='beta'),
   'aten::t': Transpose('self'),
   'aten::mm': MatMul('self', 'mat2'),
+  'aten::zeros_like': ConstantOfShape(Shape('self')), #the default constant is 0, so don't need to speicify attribute
 
   'aten::sum.dim_IntList': ReduceSum('self', 'dim', keepdims='keepdim'),
   'aten::threshold_backward': ReluGrad('grad_output', 'self'),

--- a/torch_onnxruntime/opgen/opgen/generator.py
+++ b/torch_onnxruntime/opgen/opgen/generator.py
@@ -26,6 +26,7 @@ class AttrType:
   INTS = '<unsupported:INTS>'
   STRING = 'const char*'
   STRINGS = '<unsupported:STRINGS>'
+  TENSOR = 'at::Tensor'
 
 class ONNXAttr:
   def __init__(self, value, type: AttrType=None):

--- a/torch_onnxruntime/ort_aten.cpp
+++ b/torch_onnxruntime/ort_aten.cpp
@@ -241,33 +241,6 @@ at::Tensor& copy_(
   return self;
 }
 
-at::Tensor zeros_like(
-  const at::Tensor& self,
-  // *,
-  c10::optional<at::ScalarType> dtype,
-  c10::optional<at::Layout> layout,
-  c10::optional<at::Device> device,
-  c10::optional<bool> pin_memory,
-  c10::optional<at::MemoryFormat> memory_format){
-
-  auto& invoker = GetORTInvoker(self.device());
-
-  auto ort_in_self = create_ort_value(invoker, self);
-  auto& ort_in_self_tensor = ort_in_self.Get<onnxruntime::Tensor>();
-  auto& shape = ort_in_self_tensor.Shape();
-
-  OrtValue output;
-  //todo: avoid the copy on this small shape vector;
-  auto element_type = ort_in_self_tensor.DataType();
-  CreateMLValue(invoker.GetCurrentExecutionProvider().GetAllocator(0, OrtMemTypeDefault),
-                element_type, shape.GetDims(), &output);
-  auto* output_tensor = output.GetMutable<onnxruntime::Tensor>();
-  memset(output_tensor->MutableDataRaw(element_type), 0, element_type->Size() * shape.Size());
-  return aten_tensor_from_ort(
-    std::move(output),
-    self.options());
-}
-
 at::Tensor& zero_(at::Tensor& self){
   auto& invoker = GetORTInvoker(self.device());
   auto ort_in_self = create_ort_value(invoker, self);

--- a/torch_onnxruntime/ort_log.h
+++ b/torch_onnxruntime/ort_log.h
@@ -36,7 +36,6 @@ class ORTLog {
     return *this;
   }
 
-  template<>
   ORTLog& operator<<(const at::Device device) {
     *this << "Device:" << c10::DeviceTypeName(device.type(), true);
     *this << ":" << device.index();
@@ -53,7 +52,6 @@ class ORTLog {
     return *this;
   }
 
-  template<>
   ORTLog& operator<<(const c10::Scalar scalar) {
     *this << "Scalar:" << scalar.type();
     switch (scalar.type()) {
@@ -72,7 +70,6 @@ class ORTLog {
     return *this;
   }
 
-  template<>
   ORTLog& operator<<(const at::Tensor tensor) {
     *this << "Tensor";
     return *this;
@@ -118,7 +115,11 @@ class ORTLog {
 #define ORT_LOG_VERBOSE ORT_LOG(ORTLogLevel::VERBOSE)
 #define ORT_LOG_TRACE ORT_LOG(ORTLogLevel::TRACE)
 
-#define ORT_LOG_FN(...) ORT_LOG_VERBOSE.func(__PRETTY_FUNCTION__, ##__VA_ARGS__)
+template<typename...Ts>
+inline void ORT_LOG_FN(Ts... args) {
+   ORT_LOG_VERBOSE.func(__PRETTY_FUNCTION__, args...);
+}
+//#define ORT_LOG_FN(...) ORT_LOG_VERBOSE.func(__PRETTY_FUNCTION__, ##__VA_ARGS__)
 
 } // namespace eager
 } // namespace torch_ort

--- a/torch_onnxruntime/test/ort_ops.py
+++ b/torch_onnxruntime/test/ort_ops.py
@@ -53,6 +53,13 @@ class OrtOpTests(unittest.TestCase):
     cpu_sin_pi = torch.sin(torch.Tensor([np.pi]))
     ort_sin_pi = torch.sin(torch.Tensor([np.pi]).to(device))
     assert torch.allclose(cpu_sin_pi, ort_sin_pi.cpu())
+  
+  def test_zero_like(self):
+    device = self.get_device()
+    ones = torch.ones((10, 10), dtype=torch.float32)
+    cpu_zeros = torch.zeros_like(ones)
+    ort_zeros = torch.zeros_like(ones.to(device))
+    assert torch.allclose(cpu_zeros, ort_zeros.cpu())
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
1. fix some build issue with ubuntu gcc 
2. use ConstantOfShape op to implement zeros_like, remove the hardcode implementation
