### PR TITLE
Added support for MSNPU execution provider

### DIFF
--- a/src/eager/README.md
+++ b/src/eager/README.md
@@ -3,7 +3,7 @@
 ## Dependencies & Environment
 
 ```bash
-conda install numpy ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions future six requests dataclasses pkg-config libuv llvm-openmp
+conda install numpy ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions future six requests dataclasses pkg-config libuv flake8 llvm-openmp
 ```
 
 ```bash
@@ -12,13 +12,12 @@ export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}
 
 ## Build
 
-Build pytorch first from root of this repo:
-
-```bash
-python setup.py install
+Run the following:
+```
+git submodule update --init --recursive
 ```
 
-Then go to this folder and build the torch_ort extension:
+From this folder (src/eager) build the torch_ort extension:
 ```bash
 python setup.py install
 ```

--- a/src/eager/ort_backends.h
+++ b/src/eager/ort_backends.h
@@ -6,33 +6,18 @@
 #include <torch/extension.h>
 #include <core/framework/ml_value.h>
 #include <core/eager/ort_kernel_invoker.h>
-#include <core/providers/cpu/cpu_execution_provider.h>
 
 namespace torch_ort {
 namespace eager {
 
 class ORTBackendsManager {
 public:
-  enum ORTDeviceKind : uint8_t {
-    kCPU = 1,
-    kCUDA = 2,
-    kDirectML = 3
-  };
-
   ORTBackendsManager(const onnxruntime::logging::Logger& logger) : logger_(logger) {
-    backend_kinds_[ORTDeviceKind::kCPU] = "cpu";
-    backend_kinds_[ORTDeviceKind::kCUDA] = "cuda";
-    backend_kinds_[ORTDeviceKind::kDirectML] = "direct_ml";
-  }
-
-  std::map<ORTDeviceKind, std::string>& GetBackendKinds() {
-    return backend_kinds_;
   }
 
   onnxruntime::ORTInvoker& GetInvoker(const at::Device device);
 
 private:
-  std::map<ORTDeviceKind, std::string> backend_kinds_;
   std::map<at::DeviceIndex, std::unique_ptr<onnxruntime::ORTInvoker>> backends_;
   const onnxruntime::logging::Logger& logger_;
 };

--- a/src/eager/ort_eager.cpp
+++ b/src/eager/ort_eager.cpp
@@ -12,16 +12,13 @@ namespace eager {
 PYBIND11_MODULE(torch_ort, torch_ort_module) {
   ORT_LOG_DEBUG << "pybind11 module init";
 
-  auto device_module = torch_ort_module.def_submodule("device");
-  for (auto const& entry : GetORTBackendsManager().GetBackendKinds()) {
-    device_module.def(
-      entry.second.c_str(),
-      [entry](int device_index) {
-        return py::cast<py::object>(
-          THPDevice_New(at::Device(at::DeviceType::ORT, device_index)));
-      },
-      py::arg("device_index") = 0);
-  }
+  torch_ort_module.def(
+    "device",
+    [](int device_index) {
+      return py::cast<py::object>(
+        THPDevice_New(at::Device(at::DeviceType::ORT, device_index)));
+    },
+    py::arg("device_index") = 0);
 }
 
 } // namespace eager

--- a/src/eager/ort_tensor.cpp
+++ b/src/eager/ort_tensor.cpp
@@ -100,5 +100,10 @@ bool ORTTensorImpl::has_storage() const {
   return false;
 }
 
+at::IntArrayRef ORTTensorImpl::strides() const {
+  const_cast<ORTTensorImpl*>(this)->cacheSizeMetadata();
+  return sizes_and_strides_.strides_arrayref(); 
+}
+
 } // namespace eager
 } // namespace torch_ort

--- a/src/eager/ort_tensor.h
+++ b/src/eager/ort_tensor.h
@@ -54,6 +54,8 @@ class ORTTensorImpl final : public c10::TensorImpl {
 
   bool has_storage() const override;
 
+  at::IntArrayRef strides() const override;  
+
  private:
   void cacheSizeMetadata();
   OrtValue tensor_;

--- a/src/eager/ort_util.cpp
+++ b/src/eager/ort_util.cpp
@@ -17,7 +17,7 @@ void CreateMLValue(onnxruntime::AllocatorPtr alloc,
                    const std::vector<int64_t>& dims, 
                    OrtValue* p_mlvalue) {
   onnxruntime::TensorShape shape(dims);
-  std::unique_ptr<onnxruntime::Tensor> p_tensor = onnxruntime::make_unique<onnxruntime::Tensor>(element_type,
+  std::unique_ptr<onnxruntime::Tensor> p_tensor = std::make_unique<onnxruntime::Tensor>(element_type,
                                                                       shape,
                                                                       alloc);
   p_mlvalue->Init(p_tensor.release(),
@@ -29,7 +29,7 @@ void CreateMLValue(void* data_ptr, onnxruntime::MLDataType element_type, const s
   onnxruntime::TensorShape shape(dims);
   OrtMemoryInfo *cpu_info;
   Ort::ThrowOnError(Ort::GetApi().CreateCpuMemoryInfo(OrtArenaAllocator, OrtMemTypeDefault, &cpu_info));
-  std::unique_ptr<onnxruntime::Tensor> p_tensor = onnxruntime::make_unique<onnxruntime::Tensor>(element_type,
+  std::unique_ptr<onnxruntime::Tensor> p_tensor = std::make_unique<onnxruntime::Tensor>(element_type,
                                                                       shape,
                                                                       data_ptr,
                                                                       *cpu_info);

--- a/src/eager/test/ort_ops.py
+++ b/src/eager/test/ort_ops.py
@@ -8,7 +8,7 @@ import numpy as np
 
 class OrtOpTests(unittest.TestCase):
   def get_device(self):
-    return torch_ort.device.cpu()
+    return torch_ort.device()
 
   def test_add(self):
     device = self.get_device()

--- a/src/eager/test_models/mnist_fc.py
+++ b/src/eager/test_models/mnist_fc.py
@@ -26,7 +26,7 @@ num_classes = 10
 batch_size = 128
 
 batch = torch.rand((batch_size, input_size))
-device = torch_ort.device.cpu()
+device = torch_ort.device()
 
 with torch.no_grad():
 

--- a/src/eager/test_models/scratchpad.py
+++ b/src/eager/test_models/scratchpad.py
@@ -4,7 +4,7 @@
 import torch
 import torch_ort
 
-device = torch_ort.device.cpu()
+device = torch_ort.device()
 
 ones = torch.ones(2, 3).to(device)
 print(ones.cpu())


### PR DESCRIPTION
1. Added support for MSNPU execution provider to the build.
2. Bumped ORT commit to newer version which has a few fixes.
3. Removed back end kinds. You can use torch_ort.device() to get to the device.
4. Fixed invalid stride dimension error since we were using strides without calculating it.